### PR TITLE
[minor] Remove grids from confusion matrix

### DIFF
--- a/dlutils/datavisu.py
+++ b/dlutils/datavisu.py
@@ -23,6 +23,7 @@ def plot_confusion_matrix(y, pred, classes, normalize=False):
     plt.imshow(cm, interpolation='nearest', cmap=cmap)
     plt.title(title)
     plt.colorbar()
+    plt.grid(False)
     tick_marks = np.arange(len(classes))
     plt.xticks(tick_marks, classes, rotation=45)
     plt.yticks(tick_marks, classes)


### PR DESCRIPTION
In standard confusion matrix the grid is usually in the middle of the cells. When there's few classes to display, it's nicer without grids.